### PR TITLE
Move to Binary Color for embedded graphics implementation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,33 @@ fn main() -> ! {
 }
 ```
 
+## Embedded Graphics Examples
+Make sure to have the `embedded-graphics` feature flag set. For embedded graphics `BinaryColor::Off` is a black pixel and `BinaryColor::On` is a white pixel on the display.
+
+### Text
+```rust
+    //Creates a frame buffer for embedded graphics
+    let mut fb = wepd::Framebuffer::new();
+    //Create your embedded text
+    let style = MonoTextStyle::new(&ascii::FONT_10X20, BinaryColor::Off);
+    Text::new("Hello world", Point { x: 5, y: 15 }, style)
+        .draw(&mut fb)
+        .unwrap();
+    //Write the frame buffer to the display struct made earlier
+    fb.flush(&mut display).unwrap();
+```
+
+### Images using tinybmp
+```rust
+    //Creates a frame buffer for embedded graphics
+    let mut fb = wepd::Framebuffer::new();
+    //Have bmp under 200x200 pixels in your project directory and include it
+    let bmp_data = include_bytes!("../ferris.bmp");
+    let bmp: Bmp<BinaryColor> = Bmp::from_slice(bmp_data).unwrap();
+    //Write the frame buffer to the display struct made earlier
+    fb.flush(&mut display).unwrap();
+```
+
 ## State
 
 This was a quick port from my original implementation that directly used APIs exposed by `esp-hal`.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Make sure to have the `embedded-graphics` feature flag set. For embedded graphic
     //Have bmp under 200x200 pixels in your project directory and include it
     let bmp_data = include_bytes!("../ferris.bmp");
     let bmp: Bmp<BinaryColor> = Bmp::from_slice(bmp_data).unwrap();
+    Image::new(&bmp, Point::new(50, 50)).draw(&mut fb).unwrap();
     //Write the frame buffer to the display struct made earlier
     fb.flush(&mut display).unwrap();
 ```

--- a/src/embedded_graphics.rs
+++ b/src/embedded_graphics.rs
@@ -1,16 +1,9 @@
-use embedded_graphics_core::prelude::{Dimensions, DrawTarget, PixelColor};
+use embedded_graphics_core::{
+    pixelcolor::BinaryColor,
+    prelude::{Dimensions, DrawTarget},
+};
 
 use super::*;
-
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum Color {
-    Black,
-    White,
-}
-
-impl PixelColor for Color {
-    type Raw = ();
-}
 
 pub struct Framebuffer {
     framebuffer: [u8; WIDTH * HEIGHT / 8],
@@ -44,7 +37,7 @@ impl Dimensions for Framebuffer {
 }
 
 impl DrawTarget for Framebuffer {
-    type Color = Color;
+    type Color = BinaryColor;
 
     type Error = ();
 
@@ -63,12 +56,10 @@ impl DrawTarget for Framebuffer {
             let bit_index = 7 - x % 8;
 
             match color {
-                Color::White => {
-                    *byte |= 0b1 << bit_index;
-                }
-                Color::Black => {
-                    *byte &= !(0b1 << bit_index);
-                }
+                //White Pixel
+                BinaryColor::On => *byte |= 0b1 << bit_index,
+                //Black Pixel
+                BinaryColor::Off => *byte &= !(0b1 << bit_index),
             }
         }
 


### PR DESCRIPTION
Hey, thanks for the great repo! It has been a lot of help to get going with writing rust for watchy.

In other projects, I have used [tinybmp](https://crates.io/crates/tinybmp) to write images for the display and wanted to use it here. But `Bmp` had a trait for from `PixelColor` that looks like this.

```rust
impl<C> ImageDrawable for Bmp<'_, C>
where
    C: PixelColor + From<Rgb555> + From<Rgb565> + From<Rgb888>,
{...
```

I had looked at doing an impl for each from for `Color` that was found in this project's `embedded_graphics.rs`, but found that `BinaryColor` worked fine and fit the use case pretty well since the display is just black and white. Thought I would make a PR for it. I'd assume it will probably make it a bit easier to use this driver with other 
embedded graphic crates.

Also updated the readme with some examples to help better show the changes and so others have some examples. 
